### PR TITLE
Select issue under cursor and bulk update

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,20 +19,29 @@
     "activationEvents": [
         "onCommand:redmine.listOpenIssuesAssignedToMe",
         "onCommand:redmine.openActionsForIssue",
-        "onCommand:redmine.newIssue"
+        "onCommand:redmine.newIssue",
+        "onCommand:redmine.workflowUnderCursor"
     ],
     "main": "./out/extension",
     "contributes": {
-        "commands": [{
-            "command": "redmine.listOpenIssuesAssignedToMe",
-            "title": "Redmine: List open issues assigned to me"
-        }, {
-            "command": "redmine.openActionsForIssue",
-            "title": "Redmine: Actions for issue"
-        }, {
-            "command": "redmine.newIssue",
-            "title": "Redmine: Create new issue"
-        }],
+        "commands": [
+            {
+                "command": "redmine.listOpenIssuesAssignedToMe",
+                "title": "Redmine: List open issues assigned to me"
+            },
+            {
+                "command": "redmine.openActionsForIssue",
+                "title": "Redmine: Actions for issue"
+            },
+            {
+                "command": "redmine.newIssue",
+                "title": "Redmine: Create new issue"
+            },
+            {
+                "command": "redmine.workflowUnderCursor",
+                "title": "Redmine: Workflow under cursor"
+            }
+        ],
         "configuration": {
             "title": "Redmine Integration",
             "properties": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
         "onCommand:redmine.listOpenIssuesAssignedToMe",
         "onCommand:redmine.openActionsForIssue",
         "onCommand:redmine.newIssue",
-        "onCommand:redmine.openActionsForIssueUnderCursor",
-        "onCommand:redmine.workflowUnderCursor"
+        "onCommand:redmine.openActionsForIssueUnderCursor"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -41,10 +40,6 @@
             {
                 "command": "redmine.openActionsForIssueUnderCursor",
                 "title": "Redmine: Actions for issue under cursor"
-            },
-            {
-                "command": "redmine.workflowUnderCursor",
-                "title": "Redmine: Workflow under cursor"
             }
         ],
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "onCommand:redmine.listOpenIssuesAssignedToMe",
         "onCommand:redmine.openActionsForIssue",
         "onCommand:redmine.newIssue",
+        "onCommand:redmine.openActionsForIssueUnderCursor",
         "onCommand:redmine.workflowUnderCursor"
     ],
     "main": "./out/extension",
@@ -36,6 +37,10 @@
             {
                 "command": "redmine.newIssue",
                 "title": "Redmine: Create new issue"
+            },
+            {
+                "command": "redmine.openActionsForIssueUnderCursor",
+                "title": "Redmine: Actions for issue under cursor"
             },
             {
                 "command": "redmine.workflowUnderCursor",

--- a/src/controllers/domain.ts
+++ b/src/controllers/domain.ts
@@ -1,0 +1,16 @@
+export class Membership {
+    constructor(public readonly userId: string,
+                public readonly userName: string) { }
+}
+
+export class IssueStatus {
+    constructor(public readonly statusId: string,
+                public readonly name: string) { }
+}
+
+export class BulkUpdate {
+    constructor(public readonly issueId: string,
+                public readonly message: string,
+                public readonly assignee: Membership,
+                public readonly status: IssueStatus) { }
+}

--- a/src/controllers/domain.ts
+++ b/src/controllers/domain.ts
@@ -8,14 +8,14 @@ export class IssueStatus {
                 public readonly name: string) { }
 }
 
-export class BulkUpdate {
+export class QuickUpdate {
     constructor(public readonly issueId: string,
                 public readonly message: string,
                 public readonly assignee: Membership,
                 public readonly status: IssueStatus) { }
 }
 
-export class BulkUpdateResult {
+export class QuickUpdateResult {
     public readonly differences: string[] = [];
 
     public isSuccessful() {

--- a/src/controllers/domain.ts
+++ b/src/controllers/domain.ts
@@ -14,3 +14,15 @@ export class BulkUpdate {
                 public readonly assignee: Membership,
                 public readonly status: IssueStatus) { }
 }
+
+export class BulkUpdateResult {
+    public readonly differences: string[] = [];
+
+    public isSuccessful() {
+        return this.differences.length == 0;
+    }
+
+    public addDifference(difference: string) {
+        this.differences.push(difference);
+    }
+}

--- a/src/controllers/issue-controller.ts
+++ b/src/controllers/issue-controller.ts
@@ -126,8 +126,8 @@ export class IssueController {
         const desiredAssignee = assigneeChoice.assignee;
         const message = await vscode.window.showInputBox({ placeHolder: "Message" });
 
-        const bulkUpdate = new QuickUpdate(this.issue.id, message, desiredAssignee, desiredStatus);
-        const updateResult = await this.redmine.applyQuickUpdate(bulkUpdate);
+        const quickUpdate = new QuickUpdate(this.issue.id, message, desiredAssignee, desiredStatus);
+        const updateResult = await this.redmine.applyQuickUpdate(quickUpdate);
         if(updateResult.isSuccessful()) {
             vscode.window.showInformationMessage("Issue updated");
         } else {

--- a/src/controllers/issue-controller.ts
+++ b/src/controllers/issue-controller.ts
@@ -131,7 +131,7 @@ export class IssueController {
         if(updateResult.isSuccessful()) {
             vscode.window.showInformationMessage("Issue updated");
         } else {
-            vscode.window.showErrorMessage("Issue updated partially", ...updateResult.differences);
+            vscode.window.showErrorMessage(`Issue updated partially; problems: \n${updateResult.differences.join('\t\n')}`);
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,8 +180,12 @@ export function activate(context: vscode.ExtensionContext) {
         const message = await vscode.window.showInputBox({ placeHolder: "Message" });
 
         const bulkUpdate = new BulkUpdate(issueId, message, desiredAssignee, desiredStatus);
-        await redmine.applyBulkUpdate(bulkUpdate);
-        vscode.window.showInformationMessage("Issue updated");
+        const updateResult = await redmine.applyBulkUpdate(bulkUpdate);
+        if(updateResult.isSuccessful()) {
+            vscode.window.showInformationMessage("Issue updated");
+        } else {
+            vscode.window.showErrorMessage("Could not update issue", ...updateResult.differences);
+        }
     });
 
     let newIssue = vscode.commands.registerCommand('redmine.newIssue', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { IssueController } from './controllers/issue-controller';
 import * as vscode from 'vscode';
 import * as https from 'https';
 import * as http from 'http';
-import { CancellationToken, QuickPickItem } from 'vscode';
+import { CancellationToken, QuickPickItem, Selection } from 'vscode';
 
 import { Redmine } from './redmine/redmine';
 import { BulkUpdate } from './controllers/domain';
@@ -253,34 +253,28 @@ export function activate(context: vscode.ExtensionContext) {
 
 function getIssueUnderCursor() : string | null {
     const editor = vscode.window.activeTextEditor;
-    const selection = editor.selection;
-    if(selection.isEmpty) {
-            selectWord(editor);
-    }
-    const text = editor.document.getText(editor.selection);
+    const text = getIssueIdUnderCursor(editor);
     const issueId = text.replace("#", "").replace(":", "");
     if(!/^\d+$/.test(issueId)) {
-        vscode.window.showErrorMessage(`${text} is no Issue id`);
+        vscode.window.showErrorMessage("No issue selected");
         return null;
     }
     return issueId;
 }
-function selectWord(editor: vscode.TextEditor): boolean {
-    const selection = editor.selection;
-    const doc = editor.document;
-    if (selection.isEmpty) {
-        const cursorWordRange = doc.getWordRangeAtPosition(selection.active);
 
-        if (cursorWordRange) {
-            const newSe = new vscode.Selection(cursorWordRange.start.line, cursorWordRange.start.character, cursorWordRange.end.line, cursorWordRange.end.character);
-            editor.selection = newSe;
-            return true;
-
-        } else {
-            return false;
+function getIssueIdUnderCursor(editor: vscode.TextEditor): string {
+    const currentSelection = editor.selection;
+    const document = editor.document;
+    if (currentSelection.isEmpty) {
+        const cursorWordRange = document.getWordRangeAtPosition(currentSelection.active);
+        if(cursorWordRange) {
+            const newSelection = new Selection(cursorWordRange.start.line, cursorWordRange.start.character, cursorWordRange.end.line, cursorWordRange.end.character);
+            editor.selection = newSelection;
+            return editor.document.getText(newSelection);
         }
+        return "";
     } else {
-        return true;
+        return document.getText(currentSelection);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,10 +119,11 @@ export function activate(context: vscode.ExtensionContext) {
 
             let promise = redmine.getIssueById(issueId);
 
-            promise.then(async (issue) => {
+            promise.then((issue) => {
                 if (!issue) return;
 
                 let controller = new IssueController(issue.issue, redmine);
+
                 controller.listActions();
             }, (error) => {
                 vscode.window.showErrorMessage(error);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,28 +150,38 @@ export function activate(context: vscode.ExtensionContext) {
         const memberships = await redmine.getMemberships(issue.issue.project.id);
         const possibleStatuses = await redmine.getIssueStatusesTyped();
 
-        const statusChoice = await vscode.window.showQuickPick(possibleStatuses.map(status => {
-            return {
-                "label": status.name,
-                "description": "",
-                "detail": "",
-                "status": status
+        const statusChoice = await vscode.window.showQuickPick(
+            possibleStatuses.map(status => {
+                return {
+                    "label": status.name,
+                    "description": "",
+                    "detail": "",
+                    "status": status
+                }
+            }),
+            {
+                placeHolder: `Current: ${issue.issue.status.name}`
             }
-        }));
+        );
         if(!statusChoice) {
             return;
         }
 
         const desiredStatus = statusChoice.status;
 
-        const assigneeChoice = await vscode.window.showQuickPick(memberships.map(membership => {
-            return {
-                "label": membership.userName,
-                "description": "",
-                "detail": "",
-                "assignee": membership
+        const assigneeChoice = await vscode.window.showQuickPick(
+            memberships.map(membership => {
+                return {
+                    "label": membership.userName,
+                    "description": "",
+                    "detail": "",
+                    "assignee": membership
+                }
+            }),
+            {
+                placeHolder: `Current: ${issue.issue.assigned_to.name}`
             }
-        }));
+        );
         if(!assigneeChoice) {
             return;
         }

--- a/src/redmine/redmine.ts
+++ b/src/redmine/redmine.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import * as http from 'http';
-import { Membership, IssueStatus, BulkUpdate } from '../controllers/domain';
+import { Membership, IssueStatus, BulkUpdate, BulkUpdateResult } from '../controllers/domain';
 
 export class Redmine {
     readonly pathIssuesAssignedToMe: () => string = () => { return "/issues.json?status_id=open&assigned_to_id=me" };
@@ -264,5 +264,15 @@ export class Redmine {
                 })
             )
         );
+        const issueRequest = await this.getIssueById(bulkUpdate.issueId);
+        const issue = issueRequest.issue;
+        const updateResult = new BulkUpdateResult();
+        if(issue.assigned_to.id != bulkUpdate.assignee.userId) {
+            updateResult.addDifference("Couldn't assign user");
+        }
+        if(issue.status.id != bulkUpdate.status.statusId) {
+            updateResult.addDifference("Couldn't update status");
+        }
+        return updateResult;
     }
 }

--- a/src/redmine/redmine.ts
+++ b/src/redmine/redmine.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import * as http from 'http';
-import { Membership, IssueStatus, BulkUpdate, BulkUpdateResult } from '../controllers/domain';
+import { Membership, IssueStatus, QuickUpdate, QuickUpdateResult } from '../controllers/domain';
 
 export class Redmine {
     readonly pathIssuesAssignedToMe: () => string = () => { return "/issues.json?status_id=open&assigned_to_id=me" };
@@ -250,27 +250,27 @@ export class Redmine {
                 .map(m => new Membership(m.user.id, m.user.name));
     }
 
-    async applyBulkUpdate(bulkUpdate: BulkUpdate) {
+    async applyQuickUpdate(quickUpdate: QuickUpdate) : Promise<QuickUpdateResult> {
         await this.doRequest<{ issue: any }>(
-            this.pathIssue(bulkUpdate.issueId),
+            this.pathIssue(quickUpdate.issueId),
             "PUT",
             new Buffer(
                 JSON.stringify({
                     issue: {
-                        status_id: bulkUpdate.status.statusId,
-                        assigned_to_id: bulkUpdate.assignee.userId,
-                        notes: bulkUpdate.message
+                        status_id: quickUpdate.status.statusId,
+                        assigned_to_id: quickUpdate.assignee.userId,
+                        notes: quickUpdate.message
                     }
                 })
             )
         );
-        const issueRequest = await this.getIssueById(bulkUpdate.issueId);
+        const issueRequest = await this.getIssueById(quickUpdate.issueId);
         const issue = issueRequest.issue;
-        const updateResult = new BulkUpdateResult();
-        if(issue.assigned_to.id != bulkUpdate.assignee.userId) {
+        const updateResult = new QuickUpdateResult();
+        if(issue.assigned_to.id != quickUpdate.assignee.userId) {
             updateResult.addDifference("Couldn't assign user");
         }
-        if(issue.status.id != bulkUpdate.status.statusId) {
+        if(issue.status.id != quickUpdate.status.statusId) {
             updateResult.addDifference("Couldn't update status");
         }
         return updateResult;

--- a/src/redmine/redmine.ts
+++ b/src/redmine/redmine.ts
@@ -1,5 +1,6 @@
 import * as https from 'https';
 import * as http from 'http';
+import { Membership, IssueStatus, BulkUpdate } from '../controllers/domain';
 
 export class Redmine {
     readonly pathIssuesAssignedToMe: () => string = () => { return "/issues.json?status_id=open&assigned_to_id=me" };
@@ -8,6 +9,7 @@ export class Redmine {
     readonly pathTimeEntryActivities: () => string = () => { return "/enumerations/time_entry_activities.json"; };
     readonly pathTimeEntries: () => string = () => { return "/time_entries.json"; };
     readonly pathProjects: () => string = () => { return "/projects.json"; };
+    readonly pathMemberships: (projectId: string) => string = (projectId) => { return `/projects/${projectId}/memberships.json`}
 
     /**
      * URL that will be used to open link in a browser
@@ -167,6 +169,11 @@ export class Redmine {
         }
     }
 
+    async getIssueStatusesTyped(): Promise<IssueStatus[]> {
+        const statuses = await this.getIssueStatuses();
+        return statuses.issue_statuses.map(s => new IssueStatus(s.id, s.name));
+    }
+
     timeEntryActivities: { time_entry_activities: any[] } = null;
 
     /**
@@ -228,6 +235,34 @@ export class Redmine {
         return this.doRequest<{ projects: any[] }>(
             this.pathProjects(),
             "GET"
+        );
+    }
+
+    async getMemberships(projectId: string) : Promise<Membership[]> {
+        const membershipsResponse = await this.doRequest(
+            this.pathMemberships(projectId),
+            "GET"
+        ) as { memberships: any[] };
+
+        return membershipsResponse
+                .memberships
+                .filter(m => m.user)
+                .map(m => new Membership(m.user.id, m.user.name));
+    }
+
+    async applyBulkUpdate(bulkUpdate: BulkUpdate) {
+        await this.doRequest<{ issue: any }>(
+            this.pathIssue(bulkUpdate.issueId),
+            "PUT",
+            new Buffer(
+                JSON.stringify({
+                    issue: {
+                        status_id: bulkUpdate.status.statusId,
+                        assigned_to_id: bulkUpdate.assignee.userId,
+                        notes: bulkUpdate.message
+                    }
+                })
+            )
         );
     }
 }


### PR DESCRIPTION
Hi,

thanks for your awesome plugin!

I've added a functionality which lets you do a "bulk update" of an issue, where the issue id is selected via cursor.

This way I can use it from within my TODO list.

Lets say I have the following issue:

![image](https://user-images.githubusercontent.com/2401875/51788649-cb309500-2180-11e9-93d0-8653fa9c673b.png)

I can now update the issue (status, assignee, write a comment) within one step:

![pr](https://user-images.githubusercontent.com/2401875/51788732-c5877f00-2181-11e9-8899-bd9ed10160ee.gif)


I couldn't really decide on how to name it, if you'd like to have a different name I'll do it :-)