### PR TITLE
Display subprojects as a tree and toggle back to flat view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-redmine" extension will be documented in this
 
 ## [Unreleased]
 
+### Added
+
+- [Issue #34](https://github.com/rozpuszczalny/vscode-redmine/issues/34) - display subprojects as a tree and toggle back to flat view
+
 ## 1.0.4 - 13.10.2021
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -55,8 +55,14 @@
         "icon": "$(refresh)"
       },
       {
-         "command": "redmine.toggleProjectTreeView",
-         "title": "Toggle Project View"
+         "command": "redmine.toggleTreeView",
+         "title": "Toggle Project View: Tree",
+         "icon": "$(list-tree)"
+      },
+      {
+         "command": "redmine.toggleListView",
+         "title": "Toggle Project View: List",
+         "icon": "$(list-flat)"
       }
     ],
     "views": {
@@ -90,6 +96,14 @@
         {
           "command": "redmine.refreshIssues",
           "when": "false"
+        },
+        {
+          "command": "redmine.toggleTreeView",
+          "when": "false"
+        },
+        {
+          "command": "redmine.toggleListView",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -102,8 +116,14 @@
           "when": "view == 'redmine-explorer-projects' && !hasSingleConfig"
         },
         {
-          "command": "redmine.toggleProjectTreeView",
-          "when": "view == 'redmine-explorer-projects'"   
+          "command": "redmine.toggleTreeView",
+          "when": "view == 'redmine-explorer-projects' && redmine:treeViewStyle",
+          "group": "navigation"
+        },
+        {
+          "command": "redmine.toggleListView",
+          "when": "view == 'redmine-explorer-projects' && !redmine:treeViewStyle",
+          "group": "navigation"
         },
         {
           "command": "redmine.refreshIssues",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
         "command": "redmine.refreshIssues",
         "title": "Redmine: Refresh issues",
         "icon": "$(refresh)"
+      },
+      {
+         "command": "redmine.toggleProjectTreeView",
+         "title": "Toggle Project View"
       }
     ],
     "views": {
@@ -96,6 +100,10 @@
         {
           "command": "redmine.changeDefaultServer",
           "when": "view == 'redmine-explorer-projects' && !hasSingleConfig"
+        },
+        {
+          "command": "redmine.toggleProjectTreeView",
+          "when": "view == 'redmine-explorer-projects'"   
         },
         {
           "command": "redmine.refreshIssues",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,6 @@ export function activate(context: vscode.ExtensionContext): void {
         "redmine:treeViewStyle",
         ProjectsViewStyle.LIST
       );
-      console.log("set project view style to list view");
       projectsTree.setViewStyle(ProjectsViewStyle.LIST);
     }),
     vscode.commands.registerCommand("redmine.toggleListView", () => {
@@ -186,7 +185,6 @@ export function activate(context: vscode.ExtensionContext): void {
         "redmine:treeViewStyle",
         ProjectsViewStyle.TREE
       );
-      console.log("set project view style to tree view");
       projectsTree.setViewStyle(ProjectsViewStyle.TREE);
     })
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,6 +167,7 @@ export function activate(context: vscode.ExtensionContext): void {
   });
   context.subscriptions.push(
     vscode.commands.registerCommand("redmine.refreshIssues", () => {
+      projectsTree.clearProjects();
       projectsTree.onDidChangeTreeData$.fire();
       myIssuesTree.onDidChangeTreeData$.fire();
     }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("redmine.refreshIssues", () => {
       projectsTree.onDidChangeTreeData$.fire();
       myIssuesTree.onDidChangeTreeData$.fire();
+    }),
+    vscode.commands.registerCommand("redmine.toggleProjectTreeView", () => {
+      projectsTree.toggleView();
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import newIssue from "./commands/new-issue";
 import { RedmineConfig } from "./definitions/redmine-config";
 import { ActionProperties } from "./commands/action-properties";
 import { MyIssuesTree } from "./trees/my-issues-tree";
-import { ProjectsTree } from "./trees/projects-tree";
+import { ProjectsTree, ProjectsViewStyle } from "./trees/projects-tree";
 
 export function activate(context: vscode.ExtensionContext): void {
   const bucket = {
@@ -30,6 +30,12 @@ export function activate(context: vscode.ExtensionContext): void {
     "setContext",
     "redmine:hasSingleConfig",
     vscode.workspace.workspaceFolders.length <= 1
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "redmine:treeViewStyle",
+    ProjectsViewStyle.LIST
   );
 
   const parseConfiguration = (
@@ -164,8 +170,23 @@ export function activate(context: vscode.ExtensionContext): void {
       projectsTree.onDidChangeTreeData$.fire();
       myIssuesTree.onDidChangeTreeData$.fire();
     }),
-    vscode.commands.registerCommand("redmine.toggleProjectTreeView", () => {
-      projectsTree.toggleView();
+    vscode.commands.registerCommand("redmine.toggleTreeView", () => {
+      vscode.commands.executeCommand(
+        "setContext",
+        "redmine:treeViewStyle",
+        ProjectsViewStyle.LIST
+      );
+      console.log("set project view style to list view");
+      projectsTree.setViewStyle(ProjectsViewStyle.LIST);
+    }),
+    vscode.commands.registerCommand("redmine.toggleListView", () => {
+      vscode.commands.executeCommand(
+        "setContext",
+        "redmine:treeViewStyle",
+        ProjectsViewStyle.TREE
+      );
+      console.log("set project view style to tree view");
+      projectsTree.setViewStyle(ProjectsViewStyle.TREE);
     })
   );
 }

--- a/src/redmine/models/project.ts
+++ b/src/redmine/models/project.ts
@@ -1,6 +1,9 @@
+import { ProjectParentItem } from "../redmine-project";
+
 export interface Project {
   id: string | number;
   name: string;
   description: string;
   identifier: string;
+  parent: ProjectParentItem;
 }

--- a/src/redmine/models/project.ts
+++ b/src/redmine/models/project.ts
@@ -1,9 +1,12 @@
-import { ProjectParentItem } from "../redmine-project";
-
 export interface Project {
   id: string | number;
   name: string;
   description: string;
   identifier: string;
-  parent: ProjectParentItem;
+  parent?: ProjectParentItem;
+}
+
+export interface ProjectParentItem {
+   id: string;
+   name: string;
 }

--- a/src/redmine/models/project.ts
+++ b/src/redmine/models/project.ts
@@ -7,6 +7,6 @@ export interface Project {
 }
 
 export interface ProjectParentItem {
-   id: string;
-   name: string;
+  id: string;
+  name: string;
 }

--- a/src/redmine/redmine-project.ts
+++ b/src/redmine/redmine-project.ts
@@ -1,5 +1,6 @@
 import { RedmineServer } from "./redmine-server";
 import { QuickPickItem } from "vscode";
+import { ProjectParentItem } from "./models/project";
 
 export interface RedmineProjectOptions {
   /**
@@ -11,17 +12,12 @@ export interface RedmineProjectOptions {
   name: string;
   description: string;
   identifier: string;
-  parent: ProjectParentItem;
+  parent?: ProjectParentItem;
 }
 
 export interface ProjectQuickPickItem extends QuickPickItem {
   identifier: string;
   project: RedmineProject;
-}
-
-export interface ProjectParentItem {
-   id: string;
-   name: string;
 }
 
 export class RedmineProject {

--- a/src/redmine/redmine-project.ts
+++ b/src/redmine/redmine-project.ts
@@ -11,11 +11,17 @@ export interface RedmineProjectOptions {
   name: string;
   description: string;
   identifier: string;
+  parent: ProjectParentItem;
 }
 
 export interface ProjectQuickPickItem extends QuickPickItem {
   identifier: string;
   project: RedmineProject;
+}
+
+export interface ProjectParentItem {
+   id: string;
+   name: string;
 }
 
 export class RedmineProject {
@@ -26,6 +32,10 @@ export class RedmineProject {
 
   get id() {
     return this.options.id;
+  }
+
+  get parent() {
+    return this.options.parent;
   }
 
   toQuickPickItem(): ProjectQuickPickItem {

--- a/src/redmine/redmine-server.ts
+++ b/src/redmine/redmine-server.ts
@@ -196,7 +196,8 @@ export class RedmineServer {
             (proj) =>
               new RedmineProject(this, {
                 ...proj,
-                id: `${proj.id}`, parent: proj.parent,
+                id: `${proj.id}`,
+                parent: proj.parent,
               })
           ),
         ]
@@ -351,39 +352,19 @@ export class RedmineServer {
    */
   getOpenIssuesForProject(
     project_id: number | string,
-    include_subproject: number = 1
+    include_subproject: boolean = true
   ): Promise<{ issues: Issue[] }> {
-    if (include_subproject)
+    if (include_subproject) {
       return this.doRequest<{ issues: Issue[] }>(
         `/issues.json?status_id=open&project_id=${project_id}&subproject_id=!*`,
         "GET"
       );
-    else
+    } else {
       return this.doRequest<{ issues: Issue[] }>(
         `/issues.json?status_id=open&project_id=${project_id}`,
         "GET"
       );
-  }
-
-  getProjectsByParent(
-    parent_id: string
-  ): Promise<RedmineProject[]> {
-    return this.doRequest<{ projects: Project[] }>(`/projects.json?limit=100`, "GET").then(
-      (projects) => {
-        let list: RedmineProject[] = [];
-
-        projects.projects.forEach((project) => {
-          if (project.parent != undefined)
-            if (project.parent.id == parent_id) {
-              list.push(new RedmineProject(this, {
-                ...project,
-                id: `${project.id}`, parent: project.parent,
-              }));
-            }
-        });
-
-        return list;
-      });
+    }
   }
 
   compare(other: RedmineServer) {

--- a/src/redmine/redmine-server.ts
+++ b/src/redmine/redmine-server.ts
@@ -352,7 +352,7 @@ export class RedmineServer {
    */
   getOpenIssuesForProject(
     project_id: number | string,
-    include_subproject: boolean = true
+    include_subproject = true
   ): Promise<{ issues: Issue[] }> {
     if (include_subproject) {
       return this.doRequest<{ issues: Issue[] }>(

--- a/src/trees/projects-tree.ts
+++ b/src/trees/projects-tree.ts
@@ -4,10 +4,15 @@ import { RedmineConfig } from "../definitions/redmine-config";
 import { RedmineProject } from "../redmine/redmine-project";
 import { Issue } from "../redmine/models/issue";
 
+export enum ProjectsViewStyle {
+  LIST = 0,
+  TREE = 1,
+}
+
 export class ProjectsTree
   implements vscode.TreeDataProvider<RedmineProject | Issue> {
   server: RedmineServer;
-  viewStyle: number;
+  viewStyle: ProjectsViewStyle;
   constructor() {
     const config = vscode.workspace.getConfiguration(
       "redmine"
@@ -18,7 +23,7 @@ export class ProjectsTree
       additionalHeaders: config.additionalHeaders,
       rejectUnauthorized: config.rejectUnauthorized,
     });
-    this.viewStyle = 0;
+    this.viewStyle = ProjectsViewStyle.LIST;
   }
 
   onDidChangeTreeData$ = new vscode.EventEmitter<void>();
@@ -77,8 +82,8 @@ export class ProjectsTree
     return await this.server.getProjects();
   }
 
-  toggleView() {
-    this.viewStyle = (this.viewStyle) ? 0 : 1;
+  setViewStyle(style: ProjectsViewStyle) {
+    this.viewStyle = style;
     this.onDidChangeTreeData$.fire();
   }
 

--- a/src/trees/projects-tree.ts
+++ b/src/trees/projects-tree.ts
@@ -77,6 +77,11 @@ export class ProjectsTree
     return await this.server.getProjects();
   }
 
+  toggleView() {
+    this.viewStyle = (this.viewStyle) ? 0 : 1;
+    this.onDidChangeTreeData$.fire();
+  }
+
   setServer(server: RedmineServer) {
     this.server = server;
   }

--- a/src/trees/projects-tree.ts
+++ b/src/trees/projects-tree.ts
@@ -57,14 +57,10 @@ export class ProjectsTree
     projectOrIssue?: RedmineProject | Issue
   ): Promise<(RedmineProject | Issue)[]> {
     if (projectOrIssue != null && projectOrIssue instanceof RedmineProject) {
-      if (this.viewStyle == ProjectsViewStyle.TREE) {
-        const subprojects = this.projects.filter((project) => {
-          if (project.parent) {
-            return project.parent.id == projectOrIssue.id;
-          } else {
-            return false;
-          }
-        });
+      if (this.viewStyle === ProjectsViewStyle.TREE) {
+        const subprojects = this.projects.filter(
+          (project) => project.parent && project.parent.id === projectOrIssue.id
+        );
         return subprojects.concat(
           (await this.server.getOpenIssuesForProject(projectOrIssue.id, false))
             .issues
@@ -75,18 +71,17 @@ export class ProjectsTree
         .issues;
     }
 
-    if (!this.projects || this.projects.length == 0) {
+    if (!this.projects || this.projects.length === 0) {
       this.projects = await this.server.getProjects();
     }
-    
-    if (this.viewStyle == ProjectsViewStyle.TREE) {
+
+    if (this.viewStyle === ProjectsViewStyle.TREE) {
       return this.projects.filter((project) => !project.parent);
     }
     return this.projects;
   }
 
-  clearProjects()
-  {
+  clearProjects() {
     this.projects = [];
   }
 


### PR DESCRIPTION
* **Parent** option added to RedmineProjects
* **GetProjectsByParent** function added to filter subprojects
* New parameter **include_subproject** added to **getOpenIssuesForProject**; subproject issues wont be listed under parent project, they will appear only in subproject 
* **Toggle Project View** button added to switch between subproject view and flat view