### PR TITLE
docs: add code of conduct, contribution and issue template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "vscode-redmine" extension will be documented in this
 ### Added
 
 - [Issue #34](https://github.com/rozpuszczalny/vscode-redmine/issues/34) - display subprojects as a tree and toggle back to flat view
+- Code of conduct, contributing guide and issue template
 
 ## 1.0.4 - 13.10.2021
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+github@rozpuszczalny.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Introduction
+
+First and foremost, we really want to thank you for considering contributing to vscode-redmine! We are hoping we can make this extension even better with your contribution!
+
+This guide will help you get to know the rules that improves the communication between you and the maintainers, but also how to get started quickly.
+
+We love to receive contributions from the community, like fixing the bugs, adding the documentation, proposing new features, and eventually implementing new features, and so on.
+
+Please, make sure new features and support questions related to the extension are first put in the [Discussions](https://github.com/rozpuszczalny/vscode-redmine/discussions) tab on GitHub, where we can clarify questions and discuss new features before they are made.
+
+# Ground Rules
+
+* If you come up with a new feature, discuss it first in the [Discussions](https://github.com/rozpuszczalny/vscode-redmine/discussions) tab on GitHub with the maintainers and community
+* Ensure your code is formatted with [Prettier](https://prettier.io) and checked with [eslint](https://eslint.org) (you may check both by simply running `npm run lint`)
+* Keep PRs as small possible - do not batch multiple features within a single PR
+* Try to keep PR with a single commit - otherwise maintainers may squash it into single commit
+* Name your commits using [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
+  Supported types: `fix`, `feat`, `build`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`
+
+* Be welcoming to newcomers and encourage diverse new contributors from all backgrounds. See the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+# Your First Contribution
+
+Unsure where to begin contributing to `vscode-redmine`? You can start by looking through issues labelled with 'good first issue' label.
+
+> Working on your first Pull Request? You can learn more about how to do it on this site [https://www.firsttimersonly.com/](https://www.firsttimersonly.com/)
+
+
+# Getting started
+
+1. Create your own fork of the code
+2. Do the changes in your fork
+3. If you like the change and think the project could use it:
+  * Be sure you have followed the code style for the project.
+  * Add entry to the [CHANGELOG.md](./CHANGELOG.md) under `[Unreleased]` section, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
+  * Send a pull request!
+
+# How to report a bug
+
+If you find a security vulnerability, do NOT open an issue. Email github@rozpuszczalny.com instead.
+
+When you want to create a bug report, make sure you fill out the issue template.
+
+# How to suggest a feature or enhancement
+
+`vscode-redmine` goal is to provide convenient commands and views, to boost developers work without leaving the IDE. This extension does not want to give the developer full redmine functionality, just a small portion of them, needed in day-to-day activities.
+
+Before making a suggestion, make sure it was not requested before in the Issues and Discussion tabs on GitHub.
+
+To make a suggestion, propose the feature or enhancement, please create a new discussion in the [Ideas](https://github.com/rozpuszczalny/vscode-redmine/discussions/categories/ideas) in Discussions on GitHub. Describe how a new functionality would help your workflow and provide as much context to it, so we can refine together the best possible solution to your flow.
+
+Once refined, a discussion will be transformed into issue by the maintainers and the milestone will be set up.
+
+# Code review process
+
+Your pull request will be reviewed by the maintainers of the repository. We will mainly check the coding style, code architecture and test your contribution. Please do not feel like we are judging you - we just want to make sure our codebase is aligned. 😊
+
+If you receive an approval and the pipeline checks are met, maintainers will merge your pull request into the repository. Congratulations - you're now a contributor of `vscode-redmine`! 🎉
+
+Note: maintainers are working on `vscode-redmine` as a spare-time project, we will not always make reviews immediately. We will try to do it as soon as possible, but we do not promise any deadline to respond.
+
+# Conventions
+
+## Commit messages
+
+As mentioned in the Ground rules section, please follow [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) message styles. We support following types: `fix`, `feat`, `build`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+**IMPORTANT**
+
+If you want to create a feature request, do it through [Discussions tab](https://github.com/rozpuszczalny/vscode-redmine/discussions).
+Your issue will be converted into the discussion, if it is a feature request.
+
+If the bug is related to the security issue, do NOT create an issue. Email github@rozpuszczalny.com instead.
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Missing a feature? Open an issue and let me know!_
 
 ## Requirements
 
-It's required to enable REST web services in `/settings?tab=api` of your redmine (you have to be administator of redmine server).
+It's required to enable REST web services in `/settings?tab=api` of your redmine (you have to be administrator of redmine server).
 
 ## Extension Settings
 
@@ -50,7 +50,7 @@ This extension contributes the following settings:
 
 ## Contribution
 
-Feel free to contact me, if you want to contribute. ToDo features can be found in `Projects` tab on GitHub.
+If you want to contribute to the project, please read [contributing guide](./CONTRIBUTING.md) guide.
 
 ## Known Issues
 
@@ -58,7 +58,7 @@ No known issues yet. If you found one, feel free to open an issue!
 
 ## Release Notes
 
-See `CHANGELOG.md`
+See [change log](./CHANGELOG.md)
 
 ## Attributions
 


### PR DESCRIPTION
Added a code of conduct (based on https://www.contributor-covenant.org/), contribution (based on the template https://github.com/nayafia/contributing-template) and issue template (based on GitHub's default)